### PR TITLE
Improvements in the Factory class

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,7 +10,7 @@
 
 ## 1.0.1
 
-* Marked `AmplifyPayAdapter::baseUrl` as a constant to allow it's access from plugins not in the core.
+* Marked `AmplifyPayAdapter::BASE_URL` as a constant to allow it's access from plugins not in the core.
 
 ## 1.1.0
 
@@ -28,3 +28,7 @@
 ## 1.1.2
 * BugFix - prevented an internal adapter from being overriden when adding a custom adapter with the same key as one defined in \Gbowo\GbowoFactory
 
+## 1.2.0
+* Added `Gbowo\Exception\UnknownAdapterException`. This is thrown only by the `Gbowo\GbowoFactory`
+* Improvement/BugFix - Return the instance attached to `Gbowo\GbowoFactory` ___as is___ rather than re-instantiating it - `new`ing it up . 
+This is to prevent running into dependency issues, as a custom adapter might require some certain class/config value in it's constructor. If that happens, `Gbowo\GbowoFactory` cannot figure that out as it is not a `Container`.

--- a/src/Gbowo/Exception/UnknownAdapterException.php
+++ b/src/Gbowo/Exception/UnknownAdapterException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gbowo\Exception;
+
+use Exception;
+
+class UnknownAdapterException extends Exception
+{
+}

--- a/tests/GbowoFactoryTest.php
+++ b/tests/GbowoFactoryTest.php
@@ -90,7 +90,7 @@ class GbowoFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Gbowo\Exception\UnknownAdapterException
      */
     public function testUnknownAdapterIsRequested()
     {
@@ -98,7 +98,7 @@ class GbowoFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Gbowo\Exception\UnknownAdapterException
      */
     public function testInvalidCustomAdapterIsMountedAtRuntime()
     {


### PR DESCRIPTION
Prior to this PR, the factory tries to instantiate the already bounded adapter. This can lead to dependency errors and the like.

All the factory does now is to return the instance `as is`